### PR TITLE
Made some optimizations to initial dump script

### DIFF
--- a/populate_database.py
+++ b/populate_database.py
@@ -1,5 +1,18 @@
 import psycopg2
+import psycopg2.extras
 import os
+
+def insert_into_bulk_database(cursor, data):
+    try:
+        insert_query = """
+        INSERT INTO wikipedia_data (id, title, content)
+        VALUES %s;
+        """
+        psycopg2.extras.execute_values(
+            cursor, insert_query, data, page_size=100
+        )
+    except Exception as error:
+        print(f"Error: {error}")
 
 def insert_into_database(wikiid, article_title, article_content):
     try:

--- a/use_mwxml.py
+++ b/use_mwxml.py
@@ -1,9 +1,13 @@
 import datetime
 import mwxml
 import argparse
-from populate_database import insert_into_database
+
+import psycopg2
+from populate_database import insert_into_bulk_database
 
 now = datetime.datetime.now()
+
+BULK_SIZE = 1000
 
 # Parser for manually entering a local XML article file
 parser = argparse.ArgumentParser(description='parse XML files with mwxml python package to format the XML data into python objects')
@@ -13,14 +17,30 @@ args = parser.parse_args()
 # Process XML article into a mwxml iterator
 dump = mwxml.Dump.from_file(open(args.filenames[0]))
 
+connection = psycopg2.connect(database="wikivi")
+cursor = connection.cursor()
+
+bulk_data = []
+
 # Iterate through each article in the dump
 for page in dump.pages:
     wikiid = page.id
     title = page.title
     revision_of_interest = next(page)
     text = revision_of_interest.text
-    # Populate the database
-    insert_into_database(wikiid, title, text)
+    bulk_data.append((wikiid, title, text))
+
+    if len(bulk_data) >= BULK_SIZE: 
+        insert_into_bulk_database(cursor, bulk_data)
+        bulk_data = []
+
+# If there's any remaining data, insert it
+if bulk_data:
+    insert_into_bulk_database(cursor, bulk_data)
+
+cursor.close()
+connection.commit()
+connection.close()
 
 now2 = datetime.datetime.now()
 elapsed = now2 - now


### PR DESCRIPTION
I optimized the use_mwxml file. Implemented a bulk insert and moved the database connection code outside of the loop to reduce overhead.

When testing the difference in execution speed:
**before changes:** 102 seconds
**after changes:** 32 seconds

The times may vary due to the use of different wikipedia dump files.