### PR TITLE
Added multi-threading to embeddings script + added logging for embeddings workflow + added ability to choose article limit through args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 wikivi_venv/
 xml_articles/
 __pycache__
+logs

--- a/embedding_mini.py
+++ b/embedding_mini.py
@@ -8,8 +8,6 @@ import numpy as np
 import datetime
 import concurrent.futures
 
-NUM_THREADS = 2
-
 def process_article(article_data, args):
     article_id, content = article_data
     try:
@@ -46,8 +44,8 @@ articles = cursor.fetchall()
 cursor.close()
 conn.close()
 
-print(f"Running on {NUM_THREADS} threads")
-with concurrent.futures.ThreadPoolExecutor(max_workers=NUM_THREADS) as executor:
+print(f"Running on {args.num_threads} threads")
+with concurrent.futures.ThreadPoolExecutor(max_workers=args.num_threads) as executor:
     executor.map(process_article, articles, [args]*len(articles))
 
 now2 = datetime.datetime.now()

--- a/embedding_mini.py
+++ b/embedding_mini.py
@@ -32,9 +32,11 @@ def process_article(article_data, args):
 
 now = datetime.datetime.now()
 
-parser = argparse.ArgumentParser(description="Process some integers.")
+parser = argparse.ArgumentParser(description="Embedding params")
 parser.add_argument('-e', '--embedding_path', default="/extrastorage/visualizing-impact-ml/llama.cpp/embedding", help="Path to the embeddings")
 parser.add_argument('-m', '--model_path', default="/extrastorage/visualizing-impact-ml/llama.cpp/models/open_llama_3b_v2/ggml-model-f16.gguf", help="Path to the model file")
+parser.add_argument('-n', '--num_threads', type=int, default=3, help="Number of threads for parallel processing")
+
 args = parser.parse_args()
 
 conn = psycopg2.connect(dbname="wikivi")
@@ -44,6 +46,7 @@ articles = cursor.fetchall()
 cursor.close()
 conn.close()
 
+print(f"Running on {NUM_THREADS} threads")
 with concurrent.futures.ThreadPoolExecutor(max_workers=NUM_THREADS) as executor:
     executor.map(process_article, articles, [args]*len(articles))
 

--- a/embedding_mini.py
+++ b/embedding_mini.py
@@ -7,31 +7,11 @@ import numpy as np
 
 import datetime
 import concurrent.futures
-import logging
-from logging.handlers import RotatingFileHandler
 
-log_directory = 'logs'
-if not os.path.exists(log_directory):
-    os.makedirs(log_directory)
+import log_module
 
-max_log_size = 5 * 1024 * 1024  # 5 MB
-backup_count = 1  # Keep one backup file
-
-logging.basicConfig(level=logging.INFO)
-
-llama_logger = logging.getLogger('llama_output')
-llama_handler = RotatingFileHandler(os.path.join(log_directory, 'llama_output.log'), 
-                                    maxBytes=max_log_size, backupCount=backup_count)
-log_formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-llama_handler.setFormatter(log_formatter)
-llama_logger.addHandler(llama_handler)
-
-print_logger = logging.getLogger('print_output')
-print_handler = RotatingFileHandler(os.path.join(log_directory, 'print_output.log'), 
-                                    maxBytes=max_log_size, backupCount=backup_count)
-print_handler.setFormatter(log_formatter)
-print_logger.addHandler(print_handler)
-
+llama_logger = log_module.init_logger('llama_output', 'llama_output.log')
+print_logger = log_module.init_logger('print_output', 'print_output.log')
 
 def process_article(article_data, args):
     article_id, content = article_data

--- a/embedding_mini.py
+++ b/embedding_mini.py
@@ -8,6 +8,7 @@ import concurrent.futures
 
 import log_module
 from psycopg2 import pool
+from psycopg2.extras import execute_values
 
 now = datetime.datetime.now()
 
@@ -24,7 +25,8 @@ args = parser.parse_args()
 
 conn_pool = psycopg2.pool.SimpleConnectionPool(1, args.num_threads, dbname="wikivi")
 
-def process_article(article_data, args):
+
+def generate_embedding(article_data, args):
     article_id, content = article_data
     try:
         tokens = content.split()[:512]
@@ -38,38 +40,73 @@ def process_article(article_data, args):
             llama_logger.error(stderr)
 
         embedding_list = [float(value) for value in embedding.split()]
+        return article_id, embedding_list
+    except Exception as e:
+        print_logger.error(f"Error generating embedding for article {article_id}: {e}")
+        return article_id, None
+
+def update_embeddings(batch_data, conn_pool):
+    try:
         conn = conn_pool.getconn()
         cursor = conn.cursor()
-        cursor.execute("UPDATE wikipedia_data SET embeddings = %s WHERE id = %s;", (embedding_list, article_id))
-        cursor.close()
+
+        update_query = """
+        UPDATE wikipedia_data 
+        SET embeddings = data.embeddings 
+        FROM (VALUES %s) AS data(id, embeddings) 
+        WHERE wikipedia_data.id = data.id;
+        """
+
+        execute_values(cursor, update_query, [(id, embedding) for id, embedding in batch_data if embedding is not None], template=None, page_size=100)
         conn.commit()
+        cursor.close()
     except Exception as e:
-        print_logger.error(f"Error processing article {article_id}: {e}")
+        print_logger.error(f"Error in bulk updating embeddings: {e}")
         if conn:
             conn.rollback()
     finally:
         if conn:
             conn_pool.putconn(conn)
 
-print_logger.info(f"Article limit set to: {args.limit} articles")
 
-conn = psycopg2.connect(dbname="wikivi")
-cursor = conn.cursor()
-query = "SELECT id, parsed_content from wikipedia_data where parsed_content not like '%%redirect%%' and embeddings is null limit %s;"
-cursor.execute(query, (args.limit,))
-articles = cursor.fetchall()
-cursor.close()
-conn.close()
+def main():
+    parser = argparse.ArgumentParser(description="Embedding params")
+    parser.add_argument('-e', '--embedding_path', default="/extrastorage/visualizing-impact-ml/llama.cpp/embedding", help="Path to the embeddings")
+    parser.add_argument('-m', '--model_path', default="/extrastorage/visualizing-impact-ml/llama.cpp/models/open_llama_3b_v2/ggml-model-f16.gguf", help="Path to the model file")
+    parser.add_argument('-n', '--num_threads', type=int, default=2, help="Number of threads for parallel processing of data")
+    parser.add_argument('-t', '--thread_count', type=str, default=4, help="Thread count to be used by llama to increase embedding generation speed (different than the threads used for parallel processing)")
+    parser.add_argument('-l', '--limit', type=int, default=10000, help="Limit the number of articles to process") 
+    args = parser.parse_args()
 
-print_logger.info(f"Running {args.num_threads} threads for parallel processing")
-print_logger.info(f"Running {args.thread_count} threads for embedding generation speed")
+    conn_pool = psycopg2.pool.SimpleConnectionPool(1, args.num_threads, dbname="wikivi")
 
-with concurrent.futures.ThreadPoolExecutor(max_workers=args.num_threads) as executor:
-    executor.map(process_article, articles, [args]*len(articles))
+    print_logger.info(f"Article limit set to: {args.limit} articles")
 
-conn_pool.closeall()
+    conn = psycopg2.connect(dbname="wikivi")
+    cursor = conn.cursor()
+    query = "SELECT id, parsed_content from wikipedia_data where parsed_content not like '%%redirect%%' and embeddings is null limit %s;"
+    cursor.execute(query, (args.limit,))
+    articles = cursor.fetchall()
+    cursor.close()
+    conn.close()
 
-now2 = datetime.datetime.now()
-elapsed = now2 - now
-print_logger.info(f"Total elapsed time: {elapsed.total_seconds()} seconds")
+    batch_size = 100 
+    article_batches = [articles[i:i + batch_size] for i in range(0, len(articles), batch_size)]
+
+    print_logger.info(f"Running {args.num_threads} threads for parallel processing")
+    print_logger.info(f"Running {args.thread_count} threads for embedding generation speed")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.num_threads) as executor:
+        for batch in article_batches:
+            batch_embeddings = list(executor.map(lambda x: generate_embedding(x, args), batch))
+            update_embeddings(batch_embeddings, conn_pool)
+
+    conn_pool.closeall()
+
+    now2 = datetime.datetime.now()
+    elapsed = now2 - now
+    print_logger.info(f"Total elapsed time: {elapsed.total_seconds()} seconds")
+
+if __name__ == "__main__":
+    main()
 

--- a/embedding_mini.py
+++ b/embedding_mini.py
@@ -7,6 +7,31 @@ import numpy as np
 
 import datetime
 import concurrent.futures
+import logging
+from logging.handlers import RotatingFileHandler
+
+log_directory = 'logs'
+if not os.path.exists(log_directory):
+    os.makedirs(log_directory)
+
+max_log_size = 5 * 1024 * 1024  # 5 MB
+backup_count = 1  # Keep one backup file
+
+logging.basicConfig(level=logging.INFO)
+
+llama_logger = logging.getLogger('llama_output')
+llama_handler = RotatingFileHandler(os.path.join(log_directory, 'llama_output.log'), 
+                                    maxBytes=max_log_size, backupCount=backup_count)
+log_formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+llama_handler.setFormatter(log_formatter)
+llama_logger.addHandler(llama_handler)
+
+print_logger = logging.getLogger('print_output')
+print_handler = RotatingFileHandler(os.path.join(log_directory, 'print_output.log'), 
+                                    maxBytes=max_log_size, backupCount=backup_count)
+print_handler.setFormatter(log_formatter)
+print_logger.addHandler(print_handler)
+
 
 def process_article(article_data, args):
     article_id, content = article_data
@@ -16,7 +41,10 @@ def process_article(article_data, args):
 
         process = subprocess.Popen([args.embedding_path, "--log-disable", "-p", "-", "-m", args.model_path], 
                                    stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
-        embedding, _ = process.communicate(tokenized_content)
+        embedding, stderr = process.communicate(tokenized_content)
+
+        if stderr:
+            llama_logger.error(stderr)
 
         embedding_list = [float(value) for value in embedding.split()]
         conn = psycopg2.connect(dbname="wikivi")
@@ -26,7 +54,7 @@ def process_article(article_data, args):
         cursor.close()
         conn.close()
     except Exception as e:
-        print(f"Error processing article {article_id}: {e}")
+        print_logger.error(f"Error processing article {article_id}: {e}")
 
 now = datetime.datetime.now()
 
@@ -44,11 +72,11 @@ articles = cursor.fetchall()
 cursor.close()
 conn.close()
 
-print(f"Running on {args.num_threads} threads")
+print_logger.info(f"Running on {args.num_threads} threads")
 with concurrent.futures.ThreadPoolExecutor(max_workers=args.num_threads) as executor:
     executor.map(process_article, articles, [args]*len(articles))
 
 now2 = datetime.datetime.now()
 elapsed = now2 - now
-print(elapsed.total_seconds())
+print_logger.info(f"Total elapsed time: {elapsed.total_seconds()} seconds")
 

--- a/embedding_mini.py
+++ b/embedding_mini.py
@@ -5,6 +5,31 @@ import subprocess
 import datetime
 import numpy as np
 
+import datetime
+import concurrent.futures
+
+NUM_THREADS = 2
+
+def process_article(article_data, args):
+    article_id, content = article_data
+    try:
+        tokens = content.split()[:512]
+        tokenized_content = " ".join(tokens)
+
+        process = subprocess.Popen([args.embedding_path, "--log-disable", "-p", "-", "-m", args.model_path], 
+                                   stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
+        embedding, _ = process.communicate(tokenized_content)
+
+        embedding_list = [float(value) for value in embedding.split()]
+        conn = psycopg2.connect(dbname="wikivi")
+        cursor = conn.cursor()
+        cursor.execute("UPDATE wikipedia_data SET embeddings = %s WHERE id = %s;", (embedding_list, article_id))
+        conn.commit()
+        cursor.close()
+        conn.close()
+    except Exception as e:
+        print(f"Error processing article {article_id}: {e}")
+
 now = datetime.datetime.now()
 
 parser = argparse.ArgumentParser(description="Process some integers.")
@@ -16,25 +41,11 @@ conn = psycopg2.connect(dbname="wikivi")
 cursor = conn.cursor()
 cursor.execute("SELECT id, parsed_content from wikipedia_data where parsed_content not like '%redirect%' and embeddings is null limit 10000;")
 articles = cursor.fetchall()
-
-for article_id, content in articles:
-    print(article_id)
-    tokens = content.split()[:512]
-    tokenized_content = " ".join(tokens)
-
-    # Pass relevant data to the subprocess in-memory without file I/O
-    process = subprocess.Popen([args.embedding_path, "--log-disable", "-p", "-", "-m", args.model_path], 
-                               stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
-    embedding, _ = process.communicate(tokenized_content)
-
-    embedding_list = [float(value) for value in embedding.split()]
-    cursor.execute("UPDATE wikipedia_data SET embeddings = %s WHERE id = %s;", (embedding_list, article_id))
-    conn.commit()
-
 cursor.close()
 conn.close()
-#os.remove("temp.txt")
-#os.remove("output.vec")
+
+with concurrent.futures.ThreadPoolExecutor(max_workers=NUM_THREADS) as executor:
+    executor.map(process_article, articles, [args]*len(articles))
 
 now2 = datetime.datetime.now()
 elapsed = now2 - now

--- a/embedding_mini.py
+++ b/embedding_mini.py
@@ -1,15 +1,12 @@
 import argparse
-import os
 import psycopg2
 import subprocess
 import datetime
-import numpy as np
 
 import datetime
 import concurrent.futures
 
 import log_module
-from psycopg2 import pool
 
 now = datetime.datetime.now()
 

--- a/embedding_mini.py
+++ b/embedding_mini.py
@@ -42,12 +42,15 @@ parser = argparse.ArgumentParser(description="Embedding params")
 parser.add_argument('-e', '--embedding_path', default="/extrastorage/visualizing-impact-ml/llama.cpp/embedding", help="Path to the embeddings")
 parser.add_argument('-m', '--model_path', default="/extrastorage/visualizing-impact-ml/llama.cpp/models/open_llama_3b_v2/ggml-model-f16.gguf", help="Path to the model file")
 parser.add_argument('-n', '--num_threads', type=int, default=3, help="Number of threads for parallel processing")
-
+parser.add_argument('-l', '--limit', type=int, default=10000, help="Limit the number of articles to process") 
 args = parser.parse_args()
+
+print_logger.info(f"Article limit set to: {args.limit} articles")
 
 conn = psycopg2.connect(dbname="wikivi")
 cursor = conn.cursor()
-cursor.execute("SELECT id, parsed_content from wikipedia_data where parsed_content not like '%redirect%' and embeddings is null limit 10000;")
+query = "SELECT id, parsed_content from wikipedia_data where parsed_content not like '%%redirect%%' and embeddings is null limit %s;"
+cursor.execute(query, (args.limit,))
 articles = cursor.fetchall()
 cursor.close()
 conn.close()

--- a/log_module.py
+++ b/log_module.py
@@ -1,0 +1,17 @@
+import os
+import logging
+from logging.handlers import RotatingFileHandler
+
+def init_logger(logger_name, file_name, log_directory='logs', max_log_size=5*1024*1024, backup_count=1):
+    if not os.path.exists(log_directory):
+        os.makedirs(log_directory)
+
+    logger = logging.getLogger(logger_name)
+    handler = RotatingFileHandler(os.path.join(log_directory, file_name), 
+                                  maxBytes=max_log_size, backupCount=backup_count)
+    log_formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    handler.setFormatter(log_formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+    return logger


### PR DESCRIPTION
This PR adds multi-threading with a configurable thread count using args.
Testing this locally gives a very big performance boost based on how many threads are used

I have also added logging functionality for the embeddings script, all the relevant logs are now placed in a logs folder with timestamp data for easier debugging.

I have also added a new argument to set the article limit when generating embeddings, this will help debugging (faster workflow)

I have also added connection pooling to get rid of the overhead that connecting to the database with multiple threads creates.