### PR TITLE
Fixed embeddings sometimes being generated as empty

### DIFF
--- a/embedding_mini.py
+++ b/embedding_mini.py
@@ -30,7 +30,7 @@ def generate_embedding(article_data, args):
     article_id, content = article_data
     try:
         tokens = content.split()[:512]
-        tokenized_content = " ".join(tokens)
+        tokenized_content = " ".join(tokens)[:512]
 
         process = subprocess.Popen([args.embedding_path, "--log-disable", "-p", tokenized_content, "-m", args.model_path, "-t", args.thread_count], 
                                    stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True)


### PR DESCRIPTION
This bug was caused by us not setting the token limit to 512 after joining our list into one string. This would cause llamacpp to return a max token limit error for any article that had content bigger than 512 tokens. This is now fixed